### PR TITLE
Rails 5.2 includes bug

### DIFF
--- a/constant_table_saver.gemspec
+++ b/constant_table_saver.gemspec
@@ -20,7 +20,6 @@ Currently tested against Rails 5.2 (up to 5.2.1), 5.1 (up to 5.1.6) and 5.0 (up 
 
 For earlier versions of Rails, use an older version of the gem.
 EOF
-  gem.has_rdoc     = false
   gem.author       = "Will Bryant"
   gem.email        = "will.bryant@gmail.com"
   gem.homepage     = "http://github.com/willbryant/constant_table_saver"

--- a/test/constant_table_saver_test.rb
+++ b/test/constant_table_saver_test.rb
@@ -8,6 +8,8 @@ end
 class ConstantPie < ActiveRecord::Base
   set_table_name "pies"
   constant_table
+
+  has_one :ingredient, class_name: "IngredientForConstantPie", foreign_key: 'pie_id'
   
   scope :filled_with_unicorn, -> { where(:filling => 'unicorn') }
   
@@ -234,4 +236,11 @@ class ConstantTableSaverTest < ActiveSupport::TestCase
       ConstantPie.find([max_id, max_id + 1])
     end
   end
+
+  test "it correctly loads when includes are used" do
+    IngredientForConstantPie.includes(:pie).find_by(:id => 3)
+    assert_queries(2) do
+      IngredientForConstantPie.includes(:pie).find_by(:id => 3)
+    end
+  end  
 end

--- a/test_all.rb
+++ b/test_all.rb
@@ -2,7 +2,7 @@
 
 require 'yaml'
 
-rails_versions = ["5.2.0".."5.2.1", "5.1.1".."5.1.6", "5.0.2".."5.0.6", "4.2.10"].flat_map {|spec| Array(spec).collect {|v| v.gsub /.0(\d)/, '.\\1'}}
+rails_versions = ["5.1.6", "5.2.0".."5.2.1"].flat_map {|spec| Array(spec).collect {|v| v.gsub /.0(\d)/, '.\\1'}}
 rails_envs = YAML.load(File.read("test/database.yml")).keys
 
 rails_versions.each do |version|


### PR DESCRIPTION
I realize using `includes` on a constant table is somewhat conflicting and probably not an intended use case. I do feel that the result should not be an error.

This PR is not meant to be merged. It is not a solution. I don't yet have a good solution for this problem.